### PR TITLE
fix: the 'Cancel' button on BooksPage behaves properly now

### DIFF
--- a/WPFApp_LibraryManager/Pages/BooksPage.xaml.cs
+++ b/WPFApp_LibraryManager/Pages/BooksPage.xaml.cs
@@ -240,13 +240,17 @@ namespace WPFApp_LibraryManager.Pages
         {
             _requestType = "";
 
-            BindBookToBookDetails((Book)BookList_Dtg.SelectedItem);
+            if ((Book)BookList_Dtg.SelectedItem != null)
+            {
+                BindBookToBookDetails((Book)BookList_Dtg.SelectedItem);
+                Delete_Btn.IsEnabled = true;
+                Edit_Btn.IsEnabled = true;
+            }
+
             DisableBookDetails();
 
             Cancel_Btn.IsEnabled = false;
             Save_Btn.IsEnabled = false;
-            Delete_Btn.IsEnabled = true;
-            Edit_Btn.IsEnabled = true;
             AddBook_Btn.IsEnabled = true;
         }
 


### PR DESCRIPTION
if you click 'Add book' and then 'Cancel' directly, the application no longer crashes. Instead, the application reverts to its previous state without issue.

ref: #39